### PR TITLE
Add Hanzilla Jobs to job resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A list of links with resources for Job Seekers.
 |                                            **Name**                                             |                         **Description**                         |
 | :---------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: |
 | [CS Jobs](https://docs.google.com/document/d/1VL3GqkwWWjXuK6MHGxGq81sOf0GJRr8Gxn5dlcHBXVk/edit) | A  google doc with links to various CS/CS-job related resources. [Archived Copy](./archive/cs%20jobs.docx) |
+| [Hanzilla Jobs](https://jobs.hanzilla.co/categories/software-engineering/)                      | Canada student software internships and new-grad/junior jobs.   |
 
 ### Contribute to Open Source Projects
 


### PR DESCRIPTION
## Summary

Adds Hanzilla Jobs to the General Job Seeking Resources table as a Canada-specific student/recent-grad software engineering jobs resource.

Hanzilla Jobs is a free daily-updated board with Canadian internships, co-ops, new grad, junior, and entry-level roles. I linked the software-engineering category because this repo serves CSSU members.

## Checks

- Verified the linked page returns HTTP 200 and is indexable.
- Ran `npx --yes markdownlint-cli README.md`; the new row is table-aligned. The command still reports pre-existing line-length/table issues on existing rows (not introduced by this change).
